### PR TITLE
Preserve user id and name when updating user on login

### DIFF
--- a/ckanext/saml2/plugin.py
+++ b/ckanext/saml2/plugin.py
@@ -447,6 +447,11 @@ class Saml2Plugin(p.SingletonPlugin):
             model.Session.commit()
             return model.User.get(new_user_username)
         elif update_user:
+            # Ensure the id and name fields are not updated even if present
+            # in the saml2 mapping
+            data_dict['id'] = userobj.id
+            data_dict['name'] = userobj.name
+
             allow_user_change = toolkit.asbool(
                 config.get('saml2.allow_user_changes', False))
             if allow_user_change:


### PR DESCRIPTION
update_data_dict() on the _create_or_update_user() function updates the
values of the user dict with the fields mapped from the SAML2 response,
if some of these fields are named id or name they will override the ones
on the native account and will cause a user not found error down the
line. This is reflected in a redirect loop when logging in