### PR TITLE
don't prevent changing password for native users

### DIFF
--- a/ckanext/saml2/plugin.py
+++ b/ckanext/saml2/plugin.py
@@ -210,13 +210,13 @@ def saml2_set_context_variables_after_check_for_user_update(id):
 
 
 def saml2_user_update(context, data_dict):
-    if data_dict.get('password1', '') != '' or data_dict.get('password2', '') != '':
-        raise logic.ValidationError({'password': [
-            "This field cannot be modified."]})
-
     id = logic.get_or_bust(data_dict, 'id')
     name_id = saml2_get_user_name_id(id)
     if name_id is not None:
+        if data_dict.get('password1', '') != '' or data_dict.get('password2', '') != '':
+            raise logic.ValidationError({'password': [
+                "This field cannot be modified."]})
+
         allow_user_change = toolkit.asbool(
             config.get('saml2.allow_user_changes', False))
 


### PR DESCRIPTION
The current behaviour of this plugin is that if you're using saml, nobody can change their password. This doesn't really make sense if you have a mix of saml accounts and native accounts.
In this PR I have moved the validation error to after the point where we check if the account is saml (as opposed to native).